### PR TITLE
Hide reset button

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import CodeEditor from "./components/Editor";
+import CodeEditor from "./components/Editor"; // Editor component with conditional reset button
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { WelcomeModal } from "./components/WelcomeModal";
 import { Confetti } from "./components/Confetti";
@@ -51,6 +51,7 @@ function AppContent() {
     resetState,
     loadSavedCode,
     clearModuleProgress,
+    hasCodeChanged,
   } = useCodeExecution();
 
   const {
@@ -236,6 +237,7 @@ function AppContent() {
               runCode={handleRunCodeWrapper}
               hasAttemptedSubmit={hasAttemptedSubmit}
               onResetCode={handleResetCode}
+              hasCodeChanged={hasCodeChanged}
             />
           </div>
           

--- a/client/src/components/Editor.tsx
+++ b/client/src/components/Editor.tsx
@@ -26,9 +26,10 @@ interface Props {
   readOnly?: boolean;
   hasAttemptedSubmit?: boolean;
   onResetCode?: () => void;
+  hasCodeChanged?: () => boolean; // Function to check if code has changed from original
 }
 
-export default function CodeEditor({ code, onCodeChange, packageJson, solution, runCode, readOnly, hasAttemptedSubmit, onResetCode }: Props) {
+export default function CodeEditor({ code, onCodeChange, packageJson, solution, runCode, readOnly, hasAttemptedSubmit, onResetCode, hasCodeChanged }: Props) {
   const { theme } = useTheme();
   
   const [files, setFiles] = useState<FileTab[]>([
@@ -408,7 +409,7 @@ export default function CodeEditor({ code, onCodeChange, packageJson, solution, 
                 {showSolution ? 'Hide Solution' : 'Show Solution'}
               </button>
             )}
-            {onResetCode && activeFile.id === 'server.js' && (
+            {onResetCode && activeFile.id === 'server.js' && hasCodeChanged && hasCodeChanged() && (
               <button 
                 onClick={onResetCode}
                 className="flex items-center space-x-2 px-4 py-2 rounded-lg transition-colors text-sm font-medium dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 bg-slate-200 hover:bg-slate-300 text-theme-secondary"

--- a/client/src/hooks/useCodeExecution.ts
+++ b/client/src/hooks/useCodeExecution.ts
@@ -5,6 +5,7 @@ import type { TestSuiteResult, RunResult } from "../services/moduleService";
 
 export function useCodeExecution() {
   const [code, setCode] = useState("");
+  const [originalCode, setOriginalCode] = useState("");
   const [output, setOutput] = useState("");
   const [isRunning, setIsRunning] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -24,6 +25,7 @@ export function useCodeExecution() {
   // Load saved code for a module
   const loadSavedCode = useCallback((moduleId: string, defaultCode: string) => {
     setCurrentModuleId(moduleId);
+    setOriginalCode(defaultCode);
     const savedCode = ProgressService.getCode(moduleId);
     const codeToUse = savedCode || defaultCode;
     setCode(codeToUse);
@@ -94,9 +96,15 @@ export function useCodeExecution() {
     setHasAttemptedSubmit(false);
   };
 
+  // Check if current code differs from original code
+  const hasCodeChanged = useCallback(() => {
+    return code !== originalCode;
+  }, [code, originalCode]);
+
   return {
     code,
     setCode: setCodeWithSave,
+    originalCode,
     output,
     isRunning,
     isSubmitting,
@@ -107,5 +115,6 @@ export function useCodeExecution() {
     resetState,
     loadSavedCode,
     clearModuleProgress,
+    hasCodeChanged,
   };
 }


### PR DESCRIPTION
Only show the reset button when changes have been made to the code. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The editor now detects when code has been modified and reflects this state in the UI.
  * The Reset button on the server.js tab only appears when there are actual changes to revert, reducing clutter and accidental resets.
  * The code editor panel now responds to the code-change state, improving clarity about when actions are available.
  * Improved consistency across the app by propagating the code-change indicator to relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->