### PR TITLE
Remove header reset button

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,7 +50,6 @@ function AppContent() {
     handleSubmit,
     resetState,
     loadSavedCode,
-    clearModuleProgress,
     hasCodeChanged,
   } = useCodeExecution();
 
@@ -137,13 +136,6 @@ function AppContent() {
     setActiveTab('Lab');
   };
 
-  const handleResetProgress = () => {
-    if (moduleContent) {
-      clearModuleProgress(currentModuleId);
-      setCode(moduleContent.exerciseContent.editorFiles.server);
-      resetState();
-    }
-  };
 
   const handleResetCode = () => {
     if (moduleContent) {
@@ -212,7 +204,6 @@ function AppContent() {
         showModuleDropdown={showModuleDropdown}
         onModuleDropdownToggle={() => setShowModuleDropdown(!showModuleDropdown)}
         onModuleChange={handleModuleChangeWithReset}
-        onResetProgress={handleResetProgress}
         getDifficultyColor={getDifficultyColor}
       />
 

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronDown, faRotateLeft } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { ThemeToggle } from "./ThemeToggle";
 import type { Module, ModuleContent } from "../services/moduleService";
@@ -12,7 +12,6 @@ interface HeaderProps {
   showModuleDropdown: boolean;
   onModuleDropdownToggle: () => void;
   onModuleChange: (moduleId: string) => void;
-  onResetProgress: () => void;
   getDifficultyColor: (difficulty: string) => string;
 }
 
@@ -24,7 +23,6 @@ export function Header({
   showModuleDropdown,
   onModuleDropdownToggle,
   onModuleChange,
-  onResetProgress,
   getDifficultyColor,
 }: HeaderProps) {
   return (
@@ -65,19 +63,8 @@ export function Header({
             </div>
           </div>
 
-          {/* Top Right:- Module Selector + Reset Progress + GitHub Link */}
+          {/* Top Right:- Module Selector + GitHub Link */}
           <div className="flex items-center space-x-3">
-            {/* Reset Progress Button */}
-            <button
-              onClick={onResetProgress}
-              disabled={loading}
-              className="flex items-center space-x-2 px-3 py-2 bg-theme-surface border border-theme-primary rounded-lg text-theme-primary hover:bg-slate-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              title="Reset current module progress"
-            >
-              <FontAwesomeIcon icon={faRotateLeft} className="text-sm" />
-              <span className="text-sm font-medium font-b2l hidden sm:inline">Reset</span>
-            </button>
-            
             <div className="relative module-dropdown">
               <button 
                 onClick={onModuleDropdownToggle}

--- a/client/src/hooks/useCodeExecution.ts
+++ b/client/src/hooks/useCodeExecution.ts
@@ -34,11 +34,6 @@ export function useCodeExecution() {
     return codeToUse;
   }, []);
 
-  // Clear saved progress for current module
-  const clearModuleProgress = useCallback((moduleId: string) => {
-    ProgressService.clearModuleProgress(moduleId);
-    setCode("");
-  }, []);
 
   const handleRunCode = async (currentModuleId: string, codeToRun?: string, exerciseType?: 'function' | 'server') => {
     // Handle case where codeToRun might be an object (Monaco Editor event)
@@ -125,7 +120,6 @@ export function useCodeExecution() {
     handleSubmit,
     resetState,
     loadSavedCode,
-    clearModuleProgress,
     hasCodeChanged,
   };
 }

--- a/client/src/services/progressService.ts
+++ b/client/src/services/progressService.ts
@@ -54,18 +54,6 @@ export class ProgressService {
     }
   }
 
-  /**
-   * Clear progress for a specific module
-   */
-  static clearModuleProgress(moduleId: string): void {
-    try {
-      const progress = this.getProgress();
-      delete progress[moduleId];
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
-    } catch (error) {
-      console.warn('Failed to clear module progress:', error);
-    }
-  }
 
   /**
    * Clear all user progress


### PR DESCRIPTION
Remove the duplicate header reset button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed the “Reset Progress” control from the header. Users will no longer see or use a per-module progress reset from the top bar.
  - The “Reset Code” action remains available for quickly clearing the current code editor content.

- Chores
  - Streamlined progress management behind the scenes to reduce surface area and simplify behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->